### PR TITLE
Update call for install_github

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ to install the `rGithubClient`:
 ```r
 install.packages("devtools")
 require(devtools)
-install_github("rGithubClient", "brian-bot")
+install_github("brian-bot/rGithubClient")
 ```
 
 purpose is to allow users to:


### PR DESCRIPTION
The `install_github` throws a warning when using separate username and repository name; current version uses 'username/reponame' syntax.